### PR TITLE
feat(release): update macos version used by github action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ env:
 
 jobs:
   macos-build:
-    runs-on: macos-10.15
+    runs-on: macos-11
     timeout-minutes: 60
     steps:
     - uses: actions/setup-go@v2
@@ -32,7 +32,14 @@ jobs:
       # coreutils: required by test-example.sh for the "timeout" command
       # autoconf:  required for building vde
       # automake:  required for building vde
+      # TODO: Once https://github.com/actions/runner-images/issues/6817 is 
+      #       resolved, remove run lines with "rm /usr/local/bin/*"
       run: |
+        rm /usr/local/bin/2to3
+        rm /usr/local/bin/idle3
+        rm /usr/local/bin/pydoc3
+        rm /usr/local/bin/python3
+        rm /usr/local/bin/python3-config
         brew update
         brew install qemu bash coreutils
         brew install autoconf automake


### PR DESCRIPTION
MacOS Catalina is no longer supported by Apple or GitHub https://github.blog/changelog/2022-07-20-github-actions-the-macos-10-15-actions-runner-image-is-being-deprecated-and-will-be-removed-by-8-30-22. This PR updates the runner used for MacOS to Big Sur.

Issue: https://github.com/rancher-sandbox/lima-and-qemu/issues/19
Signed-off-by: Ryan Currah <ryan@currah.ca>